### PR TITLE
Split frames for helm dialoges in i3-one-window-per-frame-mode

### DIFF
--- a/i3-integration.el
+++ b/i3-integration.el
@@ -1,6 +1,7 @@
 ;;; i3-integration.el -- using i3 IPC to integrate Emacs with i3.  -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2012, Vadim Atlygin.
+;;               2015, Jan Path
 ;; All rights reserved.
 
 ;; Author:  Vadim Atlygin <vadim.atlygin@gmail.com>
@@ -234,7 +235,8 @@ kind of buffers or least recently used ones. Works only in Emacs 24."
 
 (defun i3-display-buffer-use-some-frame (buffer alist)
   (when (and (display-graphic-p)
-             (not (member (buffer-name buffer) '("*Completions*"))))
+             (not (or (member (buffer-name buffer) '("*Completions*"))
+                      (string-match-p "^\*[Hh]elm.*\*$" (buffer-name buffer)))))
     (let* ((frame (i3-get-popup-frame-for-buffer buffer))
            (window (i3-get-window-for-frame frame)))
       (window--display-buffer buffer window 'reuse))))

--- a/i3-integration.el
+++ b/i3-integration.el
@@ -58,12 +58,14 @@ will use all of them."
   "Turns on advising of visible-frame-list function. This has the
 effect of (visible-frame-list) returning only frames that are
 situated on visible workspaces. This is the default."
+  (interactive)
   (i3-switch-advice 'visible-frame-list 'after 'i3-visible-frame-list t))
 
 (defun i3-advise-visible-frame-list-off ()
   "Turns off advising of visible-frame-list
 function. (visible-frame-list) will return all frames as i3,
 being a tiling wm, does not have minimized windows concept."
+  (interactive)
   (i3-switch-advice 'visible-frame-list 'after 'i3-visible-frame-list nil))
 
 (defun i3-one-window-per-frame-mode-on ()
@@ -72,10 +74,12 @@ emacs will not split your frames, instead it will reuse them, in
 more or less sensible manner. It will not reuse frames from
 invisible workspaces either and will prefer to replace special
 kind of buffers or least recently used ones. Works only in Emacs 24."
+  (interactive)
   (i3-one-window-per-frame-mode t))
 
 (defun i3-one-window-per-frame-mode-off ()
   "Turns off one window per frame mode. This is the default."
+  (interactive)
   (i3-one-window-per-frame-mode nil))
 
 ;;; Internal functions


### PR DESCRIPTION
I use one-window-per-frame-mode together with helm, and it was pretty annoying that it always switched to another frame for things like helm-M-x or helm-find-files etc..

I'm still very new to Emacs and Lisp so the way I'm doing it might be a bit dumb.