### PR TITLE
Let undo-tree split window

### DIFF
--- a/i3-integration.el
+++ b/i3-integration.el
@@ -239,7 +239,7 @@ kind of buffers or least recently used ones. Works only in Emacs 24."
 
 (defun i3-display-buffer-use-some-frame (buffer alist)
   (when (and (display-graphic-p)
-             (not (or (member (buffer-name buffer) '("*Completions*" "*undo-tree*"))
+             (not (or (member (buffer-name buffer) '("*Completions*" " *undo-tree*"))
                       (string-match-p "^\*[Hh]elm.*\*$" (buffer-name buffer)))))
     (let* ((frame (i3-get-popup-frame-for-buffer buffer))
            (window (i3-get-window-for-frame frame)))

--- a/i3-integration.el
+++ b/i3-integration.el
@@ -239,7 +239,7 @@ kind of buffers or least recently used ones. Works only in Emacs 24."
 
 (defun i3-display-buffer-use-some-frame (buffer alist)
   (when (and (display-graphic-p)
-             (not (or (member (buffer-name buffer) '("*Completions*"))
+             (not (or (member (buffer-name buffer) '("*Completions*" "*undo-tree*"))
                       (string-match-p "^\*[Hh]elm.*\*$" (buffer-name buffer)))))
     (let* ((frame (i3-get-popup-frame-for-buffer buffer))
            (window (i3-get-window-for-frame frame)))


### PR DESCRIPTION
Since undo-tree is just yet another dialog it doesn't need it's own window.